### PR TITLE
add line numbering to the highlight plugin

### DIFF
--- a/IkiWiki/Plugin/highlight.pm
+++ b/IkiWiki/Plugin/highlight.pm
@@ -114,7 +114,7 @@ sub htmlizeformat {
 		return;
 	}
 
-	return Encode::decode_utf8(highlight($langfile, $format, shift));
+	return Encode::decode_utf8(highlight($langfile, $format, shift, shift));
 }
 
 my %ext2lang;
@@ -188,10 +188,11 @@ sub ext2langfile ($) {
 }
 
 # Interface to the highlight C library.
-sub highlight ($$) {
+sub highlight ($$$;\%) {
 	my $langfile=shift;
 	my $extorfile=shift;
 	my $input=shift;
+	my %params=%{shift() or {}};
 
 	eval q{use highlight};
 	if ($@) {
@@ -219,6 +220,18 @@ sub highlight ($$) {
 	}
 	else {		
 		$gen=$highlighters{$langfile};
+	}
+
+	if (defined $params{linenumbers} && $params{linenumbers} eq "yes") {
+		$gen->setPrintLineNumbers(1);
+	} elsif (defined $params{linenumbers} && $params{linenumbers} =~ m/^(\d+)$/) {
+		$gen->setPrintLineNumbers(1, $1);
+	} else {
+		$gen->setPrintLineNumbers(0);
+	}
+
+	if (defined $params{numberwidth} && $params{numberwidth} =~ m/^(\d+)$/) {
+		$gen->setLineNumberWidth($1);
 	}
 
 	return "<div class=\"highlight-$extorfile\">".$gen->generateString($input)."</div>";

--- a/doc/plugins/highlight.mdwn
+++ b/doc/plugins/highlight.mdwn
@@ -35,6 +35,19 @@ You can do this for any extension or language name supported by
 the [highlight library](http://www.andre-simon.de/) -- basically anything
 you can think of should work.
 
+The plugin adds additional optional parameters to the
+[[ikiwiki/directive/format]] [[ikiwiki/directive]]. `linenumbers` may be
+set to `yes` to enable line numbering or to an arbitrary integer to
+enable line numbering starting at a specific number.  `numberwidth` may
+be set to an integer representing the total number of characters (number
+plus white space padding) to use for the line numbering column.
+
+For example:
+
+	\[[!format c linenumbers=yes """..."""]]
+	\[[!format c linenumbers=10 """..."""]]
+	\[[!format c linenumbers=yes numberwidth=2 """..."""]]
+
 ## highlighting entire source files
 
 To enable syntax highlighting of entire standalone source files, use the


### PR DESCRIPTION
I included this patch at http://ikiwiki.info/todo/highlight_line_numbers/ but never heard anything.  Is that still the proper forum for submitting patches or has this project moved to this github instance?
---
This patch exposes two of the highlight libraries options: the
ability to enable line numbering and the variable used to control
the width of the line number column.

This involved changing the way the format plugin parses parameters.
It is now capable of accepting key/value pairs as well as the previous
simple ordered arguments it required.

This also includes an update to the documentation of the highlight
plugin to advertise this feature.